### PR TITLE
Asset handlers should delegate to the next handler instead of sending…

### DIFF
--- a/src/main/java/asset/pipeline/ratpack/internal/DevelopmentAssetHandler.java
+++ b/src/main/java/asset/pipeline/ratpack/internal/DevelopmentAssetHandler.java
@@ -42,7 +42,7 @@ public class DevelopmentAssetHandler implements Handler {
     } else if (props.getIndexedPath() != null) {
       ctx.insert(single(new AssetProperties(props.getIndexedPath(), null, props.getFormat(), props.getEncoding())), this);
     } else {
-      ctx.getResponse().status(404).send();
+      ctx.next();
     }
   }
 

--- a/src/main/java/asset/pipeline/ratpack/internal/ProductionAssetHandler.java
+++ b/src/main/java/asset/pipeline/ratpack/internal/ProductionAssetHandler.java
@@ -78,7 +78,7 @@ public class ProductionAssetHandler implements Handler {
       } else if(attributeCache.isDirectory()) {
         doIndexFileNext(ctx, props);
       } else {
-        response.status(404).send();
+        ctx.next();
       }
     } else {
       readAttributes(asset, attributes -> {
@@ -89,7 +89,7 @@ public class ProductionAssetHandler implements Handler {
             doIndexFileNext(ctx, props);
           } else {
             fileCache.put(manifestPath,new AssetAttributes(false,false,false, null , null));
-            response.status(404).send();
+            ctx.next();
           }
         } else {
           response.contentTypeIfNotSet(props.getFormat());


### PR DESCRIPTION
… 404 response when a resource is not found so that client error handler can kick in when we reach the not found handler at the end of the chain.

As per an earlier chat in Slack.

I decided to go for delegating to the next handler because `AssetPipelineHandler` is configured to catch all request at the end of the pipeline in `AssetPipelineModule`. Using this approach instead of `context.clientError(404)` allows for other handlers to be added after `AssetPipelineHandler` by means of decoration to get a chance at handling a request.
